### PR TITLE
Make metadata service timeout/retry settings configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ If you need to override this default, set `S3::Signature::Version` in apt config
 S3::Signature::Version "2";
 ```
 
+### Instance metadata service
+
+You can also tweak the timeout and retry settings for requests to retrieve credentials from the instance metadata.
+
+```
+S3::MetadataService::Retries "5";
+S3::MetadataService::Timeout "2";
+```
+
+The default values are 5 retries with a 1 second timeout.
+
 ## Build
 
 [![Build Status](https://travis-ci.org/lucidsoftware/apt-boto-s3.svg?branch=master)](https://travis-ci.org/lucidsoftware/apt-boto-s3)


### PR DESCRIPTION
- Add "S3::MetadataService::Retries" and "S3::MetadataService::Timeout"
  configuration variables.
- Set more sensible default for retries than botocore provides (5
  instead of 1).
- As a side-effect, the signature setting now persists correctly.