### PR TITLE
Python3 conversion

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Architecture: all
-Depends: python-pip
+Depends: python3-pip
 Description: The fast and simple S3 transport for apt
 Maintainer: Lucid Software <ops@lucidsoftware.com>
 Package: apt-boto-s3

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,2 +1,2 @@
 #!/bin/sh
-pip install boto3
+pip3 install boto3

--- a/s3.py
+++ b/s3.py
@@ -117,7 +117,10 @@ class AptMethod(object):
         self.input = AptIO.input(pipes.input)
         self.output = AptIO.output(pipes.output)
 
-class AptRequest(collections.namedtuple('AptRequest_', ['output'])):
+class AptRequest(object):
+    def __init__(self, output):
+        self.output = output
+
     def handle_message(self, message):
         try:
             self._handle_message(message)


### PR DESCRIPTION
Hi I was wondering if you have plans to move over to Python3 for this project?

In Ubuntu 18.04 default python is now 3, so I thought I'll try converting this to 3 as well. It seems to work fine.

This is mostly automatic conversion using `2to3` with some extra edits on top of that. The only weird problem was with inheritance from `namedtuple`, basically `A->namedtuple` works fine, but 
`B->A->namedtuple` is somehow broken. Rather than figuring it out, I just made `AptRequest` derive from `object` and set `output` member manually.

Just thought I'll share this via pull request, feel free to reject this if you need to stay in python2 for a while.